### PR TITLE
GPC-8: Start CLI and CLI docs for GPP client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ from gpp_client import GPPClient
 
 client = GPPClient(
     url="https://your-gpp-api/graphql",
-    auth_token="your_token_here"
+    token="your_token_here"
 )
 
 # Create a program note

--- a/docs/source/cli/index.rst
+++ b/docs/source/cli/index.rst
@@ -1,0 +1,22 @@
+CLI Reference
+=============
+
+The `gpp` command-line interface allows users to interact with the GPP through a modern Typer-based CLI.
+
+.. typer:: gpp_client.cli.cli:app
+    :prog: gpp
+    :make-sections:
+    :width: 80
+    :theme: dark
+
+This CLI includes subcommands to manage program notes and proposals.
+
+Subcommands
+-----------
+
+Each subcommand has its own page with full documentation:
+
+.. toctree::
+    :maxdepth: 1
+
+    program-note

--- a/docs/source/cli/program-note.rst
+++ b/docs/source/cli/program-note.rst
@@ -1,0 +1,9 @@
+Program Note
+============
+
+.. typer:: gpp_client.cli.cli:app:program-note
+   :prog: gpp program-note
+   :make-sections:
+   :show-nested:
+   :width: 80
+   :theme: dark

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,7 +7,7 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath('../..'))
+sys.path.insert(0, os.path.abspath("../.."))
 
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
@@ -25,7 +25,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.viewcode",
-    "sphinx.ext.intersphinx"
+    "sphinxcontrib.typer",
 ]
 
 templates_path = ["_templates"]
@@ -48,10 +48,12 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
+
 def skip_member(app, what, name, obj, skip, options):
     if name in {"queries", "default_fields", "resource_id_field"}:
         return True  # skip this member
     return skip
+
 
 def setup(app):
     app.connect("autodoc-skip-member", skip_member)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,5 +21,6 @@ If you're just getting started, begin with the :doc:`Client <client>` section to
    quickstart
    client
    credentials
+   cli/index
    managers/index
    mixins/index

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
@@ -90,7 +90,8 @@
     }
    ],
    "source": [
-    "# loop.run_until_complete(client.program_note.create(title=\"test3\", text=\"testing the client\", program_id=\"p-23e\"))"
+    "# loop.run_until_complete(client.program_note.create(title=\"test3\", text=\"testing the client\", program_id=\"p-23e\"))\n",
+    "loop.run_until_complete(client.program_note.get_batch())"
    ]
   },
   {

--- a/gpp_client/cli/cli.py
+++ b/gpp_client/cli/cli.py
@@ -1,0 +1,9 @@
+import typer
+from .commands import program_note
+
+app = typer.Typer()
+app.add_typer(program_note.program_note, name="program-note")
+
+
+def main():
+    app()

--- a/gpp_client/cli/commands/program_note.py
+++ b/gpp_client/cli/commands/program_note.py
@@ -1,0 +1,116 @@
+import typer
+from rich.console import Console
+from rich.json import JSON
+from rich.table import Table
+
+from ...client import GPPClient
+from ...schema import enums
+from ..utils import async_command, truncate_text, truncate_title
+
+program_note = typer.Typer(help="Manage Program Notes.")
+console = Console()
+
+
+@program_note.command("get-all")
+@async_command
+async def get_all(
+    limit: int = typer.Option(100, help="Max number of results."),
+    include_deleted: bool = typer.Option(False, help="Include deleted entries."),
+):
+    """List all program notes the user has access to."""
+    client = GPPClient()
+    result = await client.program_note.get_batch(
+        limit=limit,
+        include_deleted=include_deleted,
+    )
+    notes = result.get("programNotes", {}).get("matches", [])
+
+    if not notes:
+        print_not_found()
+        return
+
+    table = Table(title="Program Notes")
+    table.add_column("ID", no_wrap=True)
+    table.add_column("Title")
+    table.add_column("Text")
+
+    for note in notes:
+        note_id = str(note.get("id", "<No ID>"))
+        title = truncate_title(note.get("title", "<No Title>"))
+        text = truncate_text(note.get("text", "<No Text>"))
+        table.add_row(note_id, title, text)
+
+    console.print(table)
+
+
+@program_note.command("get")
+@async_command
+async def get(
+    id: str = typer.Argument(..., help="ID of the program note to retrieve."),
+):
+    """Retrieve a program note by its unique ID."""
+    client = GPPClient()
+    result = await client.program_note.get_by_id(resource_id=id)
+    program_note = result.get("programNote")
+
+    if not program_note:
+        print_not_found()
+        return
+
+    console.print(JSON.from_data(program_note))
+
+
+def print_not_found():
+    console.print("[bold yellow]No program note(s) found.[/bold yellow]")
+
+
+@program_note.command("create")
+@async_command
+async def create(
+    title: str = typer.Option(..., help="Title of the note."),
+    text: str = typer.Option(..., help="Content of the note."),
+    program_id: str = typer.Option(None, help="Program ID (e.g., p-2025A-001)."),
+    program_reference: str = typer.Option(
+        None, help="Program reference (e.g., GN-2025A-Q-123)."
+    ),
+    proposal_reference: str = typer.Option(None, help="Proposal reference."),
+    is_private: bool = typer.Option(False, help="Mark note as private."),
+):
+    """Create a new program note. Must provide one identifier (e.g. program ID,
+    proposal reference, or program reference).
+    """
+    client = GPPClient()
+    note = await client.program_note.create(
+        title=title,
+        text=text,
+        program_id=program_id,
+        program_reference=program_reference,
+        proposal_reference=proposal_reference,
+        is_private=is_private,
+    )
+    console.print(JSON.from_data(note))
+
+
+@program_note.command("update")
+@async_command
+async def update(
+    id: str = typer.Argument(..., help="Program note ID (e.g., n-abc123)."),
+    title: str = typer.Option(None, help="New title."),
+    text: str = typer.Option(None, help="New text."),
+    is_private: bool = typer.Option(None, help="Change privacy status."),
+    existence: enums.Existence = typer.Option(None, help="Set existence."),
+    include_deleted: bool = typer.Option(
+        False, help="Include deleted notes in search."
+    ),
+):
+    """Update an existing program note."""
+    client = GPPClient()
+    note = await client.program_note.update_by_id(
+        resource_id=id,
+        title=title,
+        text=text,
+        is_private=is_private,
+        existence=existence,
+        include_deleted=include_deleted,
+    )
+    console.print(JSON.from_data(note["updateProgramNotes"]["programNotes"][0]))

--- a/gpp_client/cli/utils.py
+++ b/gpp_client/cli/utils.py
@@ -1,0 +1,76 @@
+__all__ = ["async_command", "truncate_string", "truncate_title", "truncate_text"]
+
+import asyncio
+import functools
+from typing import Any, Callable, Optional
+
+import typer
+from rich.console import Console
+
+console = Console()
+
+
+def async_command(func: Callable[..., Any]) -> Callable[..., None]:
+    """Decorator to run async Typer commands using asyncio.run()."""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return asyncio.run(func(*args, **kwargs))
+        except Exception as exc:
+            console.print(f"[bold red]Error:[/bold red] {exc}", style="red")
+            raise typer.Exit(code=1)
+
+    return wrapper
+
+
+def truncate_string(value: Optional[str], max_length: int) -> str:
+    """Truncate a string to a maximum length with ellipsis.
+
+    Parameters
+    ----------
+    value : str, optional
+        The string to truncate. If `None` or empty, returns an empty string.
+    max_length : int
+        Maximum number of characters allowed, including the ellipsis if applied.
+
+    Returns
+    -------
+    str
+        Truncated string, possibly with "..." appended if truncated.
+    """
+    if not value:
+        return ""
+    return value if len(value) <= max_length else value[: max_length - 3] + "..."
+
+
+def truncate_title(value: Optional[str]) -> str:
+    """Truncate a title string to a a short readable length.
+
+    Parameters
+    ----------
+    value : str, optional
+        The title to truncate.
+
+    Returns
+    -------
+    str
+        Truncated title string.
+    """
+    return truncate_string(value, max_length=20)
+
+
+def truncate_text(value: Optional[str]) -> str:
+    """Truncate a paragraph string to a short readable length.
+
+    Parameters
+    ----------
+    value : str, optional
+        The paragraph text to truncate.
+
+    Returns
+    -------
+    str
+        Truncated paragraph text.
+    """
+    return truncate_string(value, max_length=40)

--- a/gpp_client/managers/program/manager.py
+++ b/gpp_client/managers/program/manager.py
@@ -20,7 +20,7 @@ class ProgramManager(CreateMixin, GetByIdMixin, GetBatchMixin, BaseManager):
     resource_id_field = "programId"
 
     def register_submanagers(self) -> None:
-        print("CALLED")
+        pass
 
     async def get_by_id(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,12 @@ description = "Gemini Program Platform client."
 readme = "README.md"
 authors = [{ name = "NOIRLab" }]
 requires-python = ">=3.10.0"
-dependencies = ["gql[aiohttp, websockets]>=3.5.2", "astropy>=5.3.4", "toml>=0.10.2"]
+dependencies = [
+    "gql[aiohttp, websockets]>=3.5.2",
+    "astropy>=5.3.4",
+    "toml>=0.10.2",
+    "typer>=0.15.2",
+]
 version = "0.0.0"
 
 [project.optional-dependencies]
@@ -21,7 +26,10 @@ test = [
     "pytest-mock",
     "ruff",
 ]
-docs = ["sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "furo"]
+docs = ["sphinx", "sphinx-rtd-theme", "sphinx-autobuild", "furo", "sphinxcontrib-typer"]
+
+[project.scripts]
+gpp = "gpp_client.cli.cli:main"
 
 [tool.setuptools.packages.find]
 where = ["."]


### PR DESCRIPTION
- Implement `program-note` commands as example usage.
- Add `Typer`-based command structure with async support.
- Create Sphinx CLI docs using `sphinxcontrib-typer`.