### PR TITLE
GOATS-30: Remove ariadne-codegen from runtime dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,10 @@ classifiers = [
 dependencies = [
     "toml>=0.10.2",
     "typer>=0.15.3",
-    "ariadne-codegen[subscriptions]>=0.14.0",
     "click>=8.0.0,<8.2.0",
+    "httpx>=0.28.1",
+    "pydantic>=2.11.0,<3",
+    "graphql-core>=3.2.0,<3.3",
 ]
 version = "25.05.0a0"
 keywords = ["gemini", "gpp", "client", "program", "platform"]
@@ -41,6 +43,7 @@ test = [
     "pytest-remotedata",
     "pytest-mock",
     "ruff",
+    "ariadne-codegen>=0.15.0.dev1",
 ]
 docs = [
     "sphinx",
@@ -49,6 +52,7 @@ docs = [
     "furo",
     "sphinxcontrib-typer",
 ]
+codegen = ["ariadne-codegen>=0.15.0.dev1"]
 
 [project.scripts]
 gpp = "gpp_client.cli.cli:main"

--- a/src/gpp_client/api/async_base_client.py
+++ b/src/gpp_client/api/async_base_client.py
@@ -20,6 +20,8 @@ from .exceptions import (
 try:
     from websockets.client import (  # type: ignore[import-not-found,unused-ignore]
         WebSocketClientProtocol,
+    )
+    from websockets.client import (
         connect as ws_connect,
     )
     from websockets.typing import (  # type: ignore[import-not-found,unused-ignore]
@@ -31,15 +33,15 @@ except ImportError:
     from contextlib import asynccontextmanager
 
     @asynccontextmanager  # type: ignore
-    async def ws_connect(*args, **kwargs):  # pylint: disable=unused-argument
+    async def ws_connect(*args, **kwargs):
         raise NotImplementedError("Subscriptions require 'websockets' package.")
-        yield  # pylint: disable=unreachable
+        yield
 
     WebSocketClientProtocol = Any  # type: ignore[misc,assignment,unused-ignore]
     Data = Any  # type: ignore[misc,assignment,unused-ignore]
     Origin = Any  # type: ignore[misc,assignment,unused-ignore]
 
-    def Subprotocol(*args, **kwargs):  # type: ignore # pylint: disable=invalid-name
+    def Subprotocol(*args, **kwargs):  # type: ignore # noqa: N802, N803
         raise NotImplementedError("Subscriptions require 'websockets' package.")
 
 

--- a/src/gpp_client/api/base_model.py
+++ b/src/gpp_client/api/base_model.py
@@ -2,7 +2,8 @@
 
 from io import IOBase
 
-from pydantic import BaseModel as PydanticBaseModel, ConfigDict
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
 
 
 class UnsetType:

--- a/src/gpp_client/api/exceptions.py
+++ b/src/gpp_client/api/exceptions.py
@@ -77,7 +77,7 @@ class GraphQLClientGraphQLMultiError(GraphQLClientError):
         )
 
 
-class GraphQLClientInvalidMessageFormat(GraphQLClientError):
+class GraphQLClientInvalidMessageFormat(GraphQLClientError):  # noqa: N818
     def __init__(self, message: Union[str, bytes]) -> None:
         self.message = message
 


### PR DESCRIPTION
- Move ariadne-codegen to optional test and codegen extras.
- Bump ariadne-codegen to latest release.
- Regenerate client code with updated generator.