### PR TITLE
GPC-35: Multi-query support via Directors

### DIFF
--- a/docs/source/director/index.rst
+++ b/docs/source/director/index.rst
@@ -1,0 +1,27 @@
+Directors Interface
+===================
+
+This section documents the included way to interact with more than one manager to satisfy the specific needs for a service.
+
+Overview
+--------
+
+A **director** allows to interact with more than one manager but using the same interface the managers do to ask for specific elements.
+This is because the ODB is limited on the information it can bring when working with too much information so it needs to be breakdown in multiple queries from different managers to recreate more complex structures.
+
+Service-specific directors are all under an specific namespace in **Director** and uses the regular client for specific query/mutations.
+
+Use an specific director
+------------------------
+
+The director interface allows to select an specific director using the namespace for each service.
+
+.. code-block:: python
+
+   from gpp_client import GPPClient
+   from gpp_client import Director
+
+
+   client = GPPClient()
+   director = Director(client)
+   programs = await director.scheduler.program.get_all()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,6 +14,7 @@ What This Documentation Covers
 - :doc:`Authentication and Credentials <credentials>`: See the different ways to provide your API credentials.
 - :doc:`CLI Reference <cli/index>`: If you're using the CLI, explore available commands for managing configurations and interacting with resources.
 - :doc:`Resource Managers <managers/index>`: Learn how the ``ProgramManager`` and other managers work and the available API to create, delete, restore, update, and get resources from GPP.
+- :doc:`Director <director/index>`: A way to handle simultaneous managers for an specific service in GPP.
 - :doc:`GPP GraphQL Client Building Blocks <api/index>`: Explore the GraphQL API types, fields, and inputs that are essential when constructing payloads for inputs and outputs.
 
 
@@ -33,5 +34,6 @@ Then move on to the :doc:`Client Overview <client>` to see how the client is org
    credentials
    cli/index
    managers/index
+   director/index
    api/index
    contributing

--- a/src/directors/__init__.py
+++ b/src/directors/__init__.py
@@ -1,0 +1,1 @@
+from .director import Director

--- a/src/directors/base_director.py
+++ b/src/directors/base_director.py
@@ -1,0 +1,7 @@
+from src.gpp_client import GPPClient
+
+
+class BaseDirector:
+    """ Used to orchestrate various managers for a specific service"""
+    def __init__(self, client: GPPClient):
+        self.client = client

--- a/src/directors/director.py
+++ b/src/directors/director.py
@@ -1,0 +1,9 @@
+from src.directors.scheduler import SchedulerDirector
+from src.gpp_client import GPPClient
+
+
+class Director:
+    """Interface to work with different directors."""
+    def __init__(self, client: GPPClient):
+        # Add here different directors services
+        self.scheduler = SchedulerDirector(client)

--- a/src/directors/scheduler/__init__.py
+++ b/src/directors/scheduler/__init__.py
@@ -1,0 +1,1 @@
+from .schedule_director import *

--- a/src/directors/scheduler/program.py
+++ b/src/directors/scheduler/program.py
@@ -1,0 +1,95 @@
+from collections import defaultdict
+from typing import Any, List, Dict
+
+from src.gpp_client import GPPClient
+from src.gpp_client.api import WhereProgram, WhereObservation, WhereOrderObservationId
+
+
+class Program:
+    """ GPP Scheduler's program manager.
+    The following version is a stripped and tailored version of a Program Manager
+    that uses the regular client to get the program and observation information.
+    """
+    def __init__(self, client: GPPClient):
+        self.client = client
+
+    async def _traverse_for_observation(self, group: Dict[str, Any], obs_map: Dict[str, Any]) -> None:
+        """Maps the information between the groups tree and the observations retrieved from a different query.
+        Parameters
+        ----------
+        group: Dict[str, Any]
+            Root group and subsequently groups
+        obs_map: Dict[str, Any]
+            Mapping of observation ids with observation raw data.
+
+        Returns
+        -------
+
+        """
+        obs = group.get("observation")
+        if obs is not None:
+            obs_id = obs["id"]
+            obs_data = obs_map.get(obs_id)
+            if obs_data is not None:
+                group["observation"] = obs_data
+            else:
+                # No information on the ODB about the observation
+                # but the structure remains in the program.
+                # Put to None so observation doesn't get parse.
+                group["observation"] = None
+
+        if "elements" in group:
+            for child in group["elements"]:
+                await self._traverse_for_observation(child, obs_map)
+
+    async def get_all(
+            self,
+            where: WhereProgram | None = None,
+    ) -> List[dict[str, Any]]:
+        """Fetch all programs with a complete group tree and observations."""
+
+        response = await self.client.program.get_all(where=where)
+
+        programs = response.get("matches", [])
+        observations = []
+        for program in programs:
+            # Create root group
+            root = {"name": "root", "elements": []}
+            groups_elements_mapping = {}
+            children_map = defaultdict(list)
+
+            # Iterate for all elements
+            groups_in_programs = program['allGroupElements']
+            for g in groups_in_programs:
+                parent_id = g.get('parentGroupId')
+
+                if parent_id is None:
+                    root['elements'].append(g)
+                    obs = g.get('observation')
+                    elem = obs or g.get('group')
+
+                    groups_elements_mapping[elem['id']] = g
+                    if elem == obs:
+                        observations.append(elem['id'])
+                else:
+                    children_map[parent_id].append(g)
+
+                for parent_id, children in children_map.items():
+                    if parent_id in groups_elements_mapping:
+                        groups_elements_mapping[parent_id]["elements"] = children
+                    else:
+                        # Ignore orphans for now, but check for this use case in the ODB
+                        pass
+            program["elements"] = root
+
+
+        where_observation = WhereObservation(id=WhereOrderObservationId(in_=observations))
+        obs_response = await self.client.observation.get_all(where=where_observation)
+        obs_mapping = {o['id']: o for o in obs_response['matches'] }
+
+        for program in programs:
+            await self._traverse_for_observation(program["elements"], obs_mapping)
+
+        return programs
+
+

--- a/src/directors/scheduler/schedule_director.py
+++ b/src/directors/scheduler/schedule_director.py
@@ -1,0 +1,11 @@
+from .program import Program
+from ..base_director import BaseDirector
+
+__all__ = ["SchedulerDirector"]
+
+class SchedulerDirector(BaseDirector):
+    """Director used to for GPP Scheduler that allows doing multy manager queries."""
+
+    @property
+    def program(self):
+        return Program(self.client)

--- a/src/gpp_client/managers/observation.py
+++ b/src/gpp_client/managers/observation.py
@@ -10,7 +10,11 @@ from ..api.custom_fields import (
     ObservationSelectResultFields,
     ProgramFields,
     ScienceRequirementsFields,
-    UpdateObservationsResultFields,
+    UpdateObservationsResultFields, ObservationWorkflowFields, ExecutionFields, ExecutionDigestFields, SetupTimeFields,
+    TimeSpanFields, ConstraintSetFields, TimingWindowFields, TimingWindowEndAtFields, TimingWindowEndAfterFields,
+    TimingWindowRepeatFields, ElevationRangeFields, AirMassRangeFields, HourAngleRangeFields, TargetEnvironmentFields,
+    CoordinatesFields, RightAscensionFields, DeclinationFields, TargetFields, SiderealFields, ProperMotionFields,
+    ProperMotionRAFields, ProperMotionDeclinationFields, NonsiderealFields,
 )
 from ..api.custom_mutations import Mutation
 from ..api.custom_queries import Query
@@ -412,5 +416,90 @@ class ObservationManager(BaseManager):
             ),
             ObservationFields.science_requirements().fields(
                 ScienceRequirementsFields.mode
+            ),
+            ObservationFields.science_band,
+            # DEPRECATED, use calculated_workflow
+            ObservationFields.workflow().fields(
+                ObservationWorkflowFields.state
+            ),
+            # BEGIN SEQUENCE NEEDED
+            # ObservationFields.execution().fields(
+                # DEPRECATED, use calculated_digest
+            #    ExecutionFields.digest().fields(
+            #        ExecutionDigestFields.setup().fields(
+            #            SetupTimeFields.full().fields(
+            #                TimeSpanFields.seconds
+            #            ),
+            #            SetupTimeFields.reacquisition().fields(
+            #                TimeSpanFields.seconds
+            #            )
+            #        )
+            #    )
+            #),
+            # END SEQUENCE
+            ObservationFields.constraint_set().fields(
+                ConstraintSetFields.image_quality,
+                ConstraintSetFields.cloud_extinction,
+                ConstraintSetFields.sky_background,
+                ConstraintSetFields.water_vapor,
+                ConstraintSetFields.elevation_range().fields(
+                    ElevationRangeFields.air_mass().fields(
+                        AirMassRangeFields.min,
+                        AirMassRangeFields.max,
+                    ),
+                    ElevationRangeFields.hour_angle().fields(
+                        HourAngleRangeFields.min_hours,
+                        HourAngleRangeFields.max_hours,
+                    )
+                )
+            ),
+            ObservationFields.timing_windows().fields(
+                TimingWindowFields.inclusion,
+                TimingWindowFields.start_utc,
+                TimingWindowFields.end.on("TimingWindowEndAt", TimingWindowEndAtFields.at_utc),
+                TimingWindowFields.end.on("TimingWindowEndAfter",
+                    TimingWindowEndAfterFields.after().fields(
+                    TimeSpanFields.seconds
+                ),
+                                          TimingWindowEndAfterFields.repeat().fields(
+                                              TimingWindowRepeatFields.period().fields(
+                                                  TimeSpanFields.seconds
+                                              ),
+                                              TimingWindowRepeatFields.times
+                                          )),
+
+            ),
+            ObservationFields.target_environment().fields(
+                TargetEnvironmentFields.asterism(include_deleted).fields(
+                        TargetFields.sidereal().fields(
+                            SiderealFields.ra().fields(
+                                RightAscensionFields.hms
+                            ),
+                            SiderealFields.dec().fields(
+                                DeclinationFields.dms
+                            ),
+                            SiderealFields.proper_motion().fields(
+                                ProperMotionFields.ra().fields(
+                                    ProperMotionRAFields.milliarcseconds_per_year
+                                ),
+                                ProperMotionFields.dec().fields(
+                                    ProperMotionDeclinationFields.milliarcseconds_per_year
+                                )
+                            ),
+                            SiderealFields.epoch,
+                        ),
+                        TargetFields.nonsidereal().fields(
+                            NonsiderealFields.des,
+                        ),
+                        TargetFields.name
+                ),
+                TargetEnvironmentFields.explicit_base().fields(
+                    CoordinatesFields.ra().fields(
+                        RightAscensionFields.hms
+                    ),
+                    CoordinatesFields.dec().fields(
+                        DeclinationFields.dms
+                    )
+                ),
             ),
         )

--- a/src/gpp_client/managers/program.py
+++ b/src/gpp_client/managers/program.py
@@ -9,7 +9,7 @@ from ..api.custom_fields import (
     ProgramFields,
     ProgramSelectResultFields,
     ProgramUserFields,
-    UpdateProgramsResultFields,
+    UpdateProgramsResultFields, GroupElementFields, GroupFields, ObservationFields, TimeSpanFields,
 )
 from ..api.custom_mutations import Mutation
 from ..api.custom_queries import Query
@@ -321,5 +321,26 @@ class ProgramManager(BaseManager):
             ProgramFields.proposal_status,
             ProgramFields.pi().fields(
                 ProgramUserFields.id,
+            ),
+            ProgramFields.all_group_elements(include_deleted).fields(
+                GroupElementFields.parent_group_id,
+                GroupElementFields.observation().fields(
+                    ObservationFields.id,
+                    ObservationFields.group_id
+                ),
+                GroupElementFields.group().fields(
+                    GroupFields.id,
+                    GroupFields.name,
+                    GroupFields.minimum_required,
+                    GroupFields.ordered,
+                    GroupFields.parent_id,
+                    GroupFields.parent_index,
+                    GroupFields.minimum_interval().fields(
+                        TimeSpanFields.seconds
+                    ),
+                    GroupFields.maximum_interval().fields(
+                        TimeSpanFields.seconds
+                    )
+                )
             ),
         )


### PR DESCRIPTION
First approach to handling more than one manager for an specific query emulating the managers behavior. 
This PR adds:

- The Director interface to handle specific queries for specific services under a namespace.
-  The Scheduler Director to retrieve full programs.
-  Modifications to the base fields in some managers (program and observation).
- Some documentation (I'm not that well versed on sphinx so if I have to do some extra step, @davner please let me know)

On the last point while it shouldn't break things maybe we are going to come up with a way to select different fields for different stuff (e.g cli vs director) because some fields are special or more hard to obtain for the ODB. Again, for now not an issue. 

