### PR TITLE
GPC-42: Add raise for status when checking if GPP is reachable.

### DIFF
--- a/src/gpp_client/client/client.py
+++ b/src/gpp_client/client/client.py
@@ -159,7 +159,9 @@ class GPPClient:
             }
         """
         try:
-            await self._client.execute(query)
+            response = await self._client.execute(query)
+            # Raise for any responses which are not a 2xx success code.
+            response.raise_for_status()
             return True, None
         except Exception as exc:
             return False, str(exc)


### PR DESCRIPTION
Adds `raise_for_status` in `client.is_reachable()` because it was wrongly assumed it did this by default with `execute`.