### PR TITLE
GPC-54 GPC-55 GPC-57: Extend GOATS director and documentation.

### DIFF
--- a/docs/source/director/goats.rst
+++ b/docs/source/director/goats.rst
@@ -1,0 +1,32 @@
+GOATS
+=====
+
+The ``GOATSDirector`` exposes **coordinator** objects that orchestrate
+several *managers* to satisfy GOATS-specific workflows.
+
+Usage Example
+-------------
+
+.. code-block:: python
+
+   from gpp_client import GPPClient
+   from gpp_client import Director
+   client = GPPClient()
+   director = Director(client)
+   observations = await director.goats.observation.get_all()
+
+
+.. automodule:: gpp_client.directors.goats
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :show-inheritance:
+
+Coordinator Layer
+-----------------
+
+.. automodule:: gpp_client.directors.goats.coordinators.observation
+   :members:
+   :undoc-members:
+   :inherited-members:
+   :show-inheritance:

--- a/docs/source/director/index.rst
+++ b/docs/source/director/index.rst
@@ -50,3 +50,4 @@ API Reference
 
    base
    scheduler
+   goats

--- a/docs/source/director/scheduler.rst
+++ b/docs/source/director/scheduler.rst
@@ -22,7 +22,7 @@ Usage Example
    :inherited-members:
    :show-inheritance:
 
-Coordinator layer
+Coordinator Layer
 -----------------
 
 Each coordinator bundles related manager calls into a single, domain-focused API.  For example, ``ProgramCoordinator`` combines ``ProgramManager`` and ``ObservationManager`` to return a program plus its observation hierarchy in one asynchronous method.

--- a/src/gpp_client/directors/goats/coordinators/observation.py
+++ b/src/gpp_client/directors/goats/coordinators/observation.py
@@ -27,4 +27,4 @@ class ObservationCoordinator(BaseCoordinator):
         results = await self.client._client.get_goats_observations(
             program_id=program_id
         )
-        return results.model_dump()
+        return results.model_dump()["observations"]

--- a/src/queries/goats.graphql
+++ b/src/queries/goats.graphql
@@ -9,6 +9,7 @@ query GetGOATSObservations($programId: ProgramId!) {
   ) {
     matches {
       id
+      reference
       instrument
       title
       constraintSet {
@@ -73,6 +74,7 @@ query GetGOATSObservations($programId: ProgramId!) {
       }
       observerNotes
       execution {
+        executionState
         visits {
           matches {
             id


### PR DESCRIPTION
- Adds in more fields for the GOATS director. 
- Changes the return payload for the GOATS director. 
- Adds documentation for the GOATS director.