### PR TITLE
Disable draft releases.

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -51,5 +51,5 @@ jobs:
         with:
           tag_name: "v${{ inputs.version }}"
           name: "v${{ inputs.version }}"
-          draft: true
+          draft: false
           generate_release_notes: true


### PR DESCRIPTION
Now that the workflow has been tested, we can disable creating a draft release and go straight to publishing.