### PR TITLE
GSCHED-870: Add system to scheduler and program query.

### DIFF
--- a/src/gpp_client/api/_client.py
+++ b/src/gpp_client/api/_client.py
@@ -297,6 +297,7 @@ class _GPPClient(AsyncBaseClient):
                       maximumInterval {
                         seconds
                       }
+                      system
                     }
                     observation {
                       id

--- a/src/gpp_client/api/get_scheduler_programs.py
+++ b/src/gpp_client/api/get_scheduler_programs.py
@@ -150,6 +150,7 @@ class GetSchedulerProgramsProgramsMatchesAllGroupElementsGroup(BaseModel):
     maximum_interval: Optional[
         "GetSchedulerProgramsProgramsMatchesAllGroupElementsGroupMaximumInterval"
     ] = Field(alias="maximumInterval")
+    system: bool
 
 
 class GetSchedulerProgramsProgramsMatchesAllGroupElementsGroupMinimumInterval(

--- a/src/gpp_client/managers/program.py
+++ b/src/gpp_client/managers/program.py
@@ -358,6 +358,7 @@ class ProgramManager(BaseManager):
                     GroupFields.parent_index,
                     GroupFields.minimum_interval().fields(TimeSpanFields.seconds),
                     GroupFields.maximum_interval().fields(TimeSpanFields.seconds),
+                    GroupFields.system,
                 ),
             ),
         )

--- a/src/queries/scheduler.graphql
+++ b/src/queries/scheduler.graphql
@@ -65,6 +65,7 @@ query GetSchedulerPrograms($programsList: [ProgramId!]) {
           maximumInterval {
             seconds
           }
+          system
         }
         observation {
           id


### PR DESCRIPTION
My workflow to add this was to:
1. Modify `src/queries/scheduler.graphql` and add system to the correct place in the query.
2. Modify `src/gpp_client/managers/program.py` and add to `def _fields` and add `GroupFields.system,`
3. Run the codegen using the command `uv run --group codegen python scripts/run_codegen.py`
