### PR TITLE
Release 26.4.1dev1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "typer>=0.21.1",
     "websockets>=14.2",
 ]
-version = "26.4.0"
+version = "26.4.1.dev1"
 keywords = ["gemini", "gpp", "client", "program", "platform"]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "gpp-client"
-version = "26.4.0"
+version = "26.4.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
# GPP-Client Release Pull Request
<!-- This pull request prepares a new **GPP-Client** release. -->

## Versioning
- [x] Bump the version using `uv version <VERSION>` (this updates `pyproject.toml` and `uv.lock`).
- [ ] For production releases: version follows `YY.MM.PATCH` (e.g., `25.11.0`).
- [x] For development releases: version must have `devN` suffix. (e.g., `25.11.0.dev1`).

## Documentation
- [ ] Build documentation locally and confirm no warnings or link issues.
```console
uv run --group docs sphinx-autobuild docs/source docs/build
```

## Validation
- [x] Generated types (`ariadne-codegen`) are up to date.
- [x] All tests pass on CI.

## Final Checks
- [x] PR is labeled as a release-preparation PR.

## Post-Merge (informational)
After this pull request is merged:

- Run the **Create Release** workflow from GitHub Actions.
- The workflow will create:
  - A properly versioned Git tag
  - A draft GitHub Release with auto-generated notes
- Make sure to publish the release and properly mark if a pre-release if development

No additional commits should be pushed to the branch between merging this PR and running the release workflow.
