### PR TITLE
GPC-183: Dynamic versioning 

### DIFF
--- a/.github/workflows/check_codegen.yaml
+++ b/.github/workflows/check_codegen.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install uv and setup the python version
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -3,39 +3,53 @@ name: Create Release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: "Release version (e.g., 25.11.0 or or 25.11.0-dev.1). Do not include a leading 'v' or unnecessary zero padding."
+      tag:
+        description: "Release tag, e.g. v26.5.0 or v26.5.0.dev1."
         required: true
-      base_branch:
-        description: "Branch the PR should target (main or dev)."
-        required: true
-        default: "main"
+
+permissions:
+  contents: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version:
-          - "3.12"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.base_branch }}
 
-      - name: Create tag
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Validate release
+        run: python scripts/validate_release.py "${{ inputs.tag }}"
+
+      - name: Check tag does not already exist
+        run: |
+          if git rev-parse "${{ inputs.tag }}" >/dev/null 2>&1; then
+            echo "Tag already exists: ${{ inputs.tag }}"
+            exit 1
+          fi
+
+      - name: Show release commit
+        run: |
+          echo "Tagging commit:"
+          git log -1 --oneline
+
+      - name: Create and push tag
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ inputs.version }}" -m "Release v${{ inputs.version }}."
-          git push origin "v${{ inputs.version }}"
+          git tag -a "${{ inputs.tag }}" -m "Release ${{ inputs.tag }}."
+          git push origin "${{ inputs.tag }}"
 
-      - name: Create GitHub release and upload artifacts
+      - name: Create draft GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: "v${{ inputs.version }}"
-          name: "v${{ inputs.version }}"
+          tag_name: ${{ inputs.tag }}
+          name: ${{ inputs.tag }}
           draft: true
           generate_release_notes: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,7 +3,6 @@ name: Upload Python Package
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: read
@@ -14,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - name: Install Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v7

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,7 +15,7 @@ build:
       - asdf install uv latest
       - asdf global uv latest
       # Only sync the docs group.
-      - UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs
+      - UV_DYNAMIC_VERSIONING_BYPASS=0.0.0 UV_PROJECT_ENVIRONMENT=$READTHEDOCS_VIRTUALENV_PATH uv sync --group docs
     install:
       - "true"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["setuptools"]
-build-backend = "setuptools.build_meta"
+requires = ["hatchling", "uv-dynamic-versioning"]
+build-backend = "hatchling.build"
 
 [project]
 name = "gpp-client"
@@ -30,12 +30,28 @@ dependencies = [
     "typer>=0.21.1",
     "websockets>=14.2",
 ]
-version = "26.4.1.dev1"
+dynamic = ["version"]
 keywords = ["gemini", "gpp", "client", "program", "platform"]
 
-[tool.setuptools.packages.find]
-where = ["src"]
-include = ["gpp_client*"]
+[tool.hatch.version]
+source = "uv-dynamic-versioning"
+
+[tool.uv-dynamic-versioning]
+style = "pep440"
+pattern = '^v(?P<base>\d{2}\.\d{1,2}\.\d+)(?:\.(?P<stage>dev)(?P<revision>\d+))?$'
+strict = true
+metadata = false
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/gpp_client"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "src/gpp_client",
+    "README.md",
+    "LICENSE",
+    "pyproject.toml",
+]
 
 [project.scripts]
 gpp = "gpp_client.cli.cli:main"

--- a/scripts/check_release.py
+++ b/scripts/check_release.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Validate release tag and package environment consistency.
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import Final
+
+TAG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^v\d{2}\.\d{1,2}\.\d+(?:\.dev\d+)?$")
+ENV_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r'^PACKAGE_ENVIRONMENT\s*=\s*["\']'
+    r'(?P<environment>DEVELOPMENT|PRODUCTION)["\']\s*$',
+    re.MULTILINE,
+)
+ENV_FILE: Final[Path] = Path("src/gpp_client/generated/package_environment.py")
+
+
+class ReleaseValidationError(RuntimeError):
+    """
+    Raised when release validation fails.
+    """
+
+
+def _parse_environment(path: Path = ENV_FILE) -> str:
+    """
+    Extract the generated package environment.
+
+    Parameters
+    ----------
+    path : Path, default=ENV_FILE
+        Path to the generated package environment file.
+
+    Returns
+    -------
+    str
+        Package environment value.
+
+    Raises
+    ------
+    ReleaseValidationError
+        Raised if the environment file is missing or invalid.
+    """
+    if not path.exists():
+        raise ReleaseValidationError(f"Missing environment file: {path}")
+
+    match = ENV_PATTERN.search(path.read_text(encoding="utf-8"))
+    if match is None:
+        raise ReleaseValidationError(
+            f"Could not find a valid PACKAGE_ENVIRONMENT in {path}."
+        )
+
+    return match.group("environment")
+
+
+def _expected_environment(tag: str) -> str:
+    """
+    Return the expected package environment for a release tag.
+
+    Parameters
+    ----------
+    tag : str
+        Release tag.
+
+    Returns
+    -------
+    str
+        Expected package environment.
+    """
+    return "DEVELOPMENT" if ".dev" in tag else "PRODUCTION"
+
+
+def validate_release(tag: str, env_file: Path = ENV_FILE) -> None:
+    """
+    Validate release tag format and package environment consistency.
+
+    Parameters
+    ----------
+    tag : str
+        Release tag, including the leading ``v``.
+    env_file : Path, optional
+        Path to the generated package environment file.
+
+    Raises
+    ------
+    ReleaseValidationError
+        Raised if the release tag or package environment is invalid.
+    """
+    if TAG_PATTERN.fullmatch(tag) is None:
+        raise ReleaseValidationError(
+            f"Invalid release tag: {tag}. Expected format: v26.5.0 or v26.5.0.dev1."
+        )
+
+    expected = _expected_environment(tag)
+    actual = _parse_environment(env_file)
+
+    if actual != expected:
+        raise ReleaseValidationError(
+            "Package environment does not match release tag.\n"
+            f"Tag: {tag}\n"
+            f"Expected PACKAGE_ENVIRONMENT: {expected}\n"
+            f"Actual PACKAGE_ENVIRONMENT: {actual}"
+        )
+
+
+def main() -> None:
+    """
+    Validate release inputs from the command line.
+    """
+    if len(sys.argv) != 2:
+        raise SystemExit("Usage: validate_release.py <tag>")
+
+    try:
+        validate_release(sys.argv[1])
+    except ReleaseValidationError as exc:
+        print(exc, file=sys.stderr)
+        raise SystemExit(1) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/validate_release.py
+++ b/scripts/validate_release.py
@@ -8,7 +8,9 @@ import sys
 from pathlib import Path
 from typing import Final
 
-TAG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^v\d{2}\.\d{1,2}\.\d+(?:\.dev\d+)?$")
+TAG_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^v\d{2}\.(?:[1-9]|1[0-2])\.\d+(?:\.dev\d+)?$"
+)
 ENV_PATTERN: Final[re.Pattern[str]] = re.compile(
     r'^PACKAGE_ENVIRONMENT\s*=\s*["\']'
     r'(?P<environment>DEVELOPMENT|PRODUCTION)["\']\s*$',
@@ -71,7 +73,7 @@ def _expected_environment(tag: str) -> str:
     return "DEVELOPMENT" if ".dev" in tag else "PRODUCTION"
 
 
-def validate_release(tag: str, env_file: Path = ENV_FILE) -> None:
+def validate_release(tag: str, env_file: Path | None = None) -> None:
     """
     Validate release tag format and package environment consistency.
 
@@ -79,14 +81,17 @@ def validate_release(tag: str, env_file: Path = ENV_FILE) -> None:
     ----------
     tag : str
         Release tag, including the leading ``v``.
-    env_file : Path, optional
-        Path to the generated package environment file.
+    env_file : Path | None, optional
+        Path to the generated package environment file. If ``None``, the default
+        ``ENV_FILE`` is used.
 
     Raises
     ------
     ReleaseValidationError
         Raised if the release tag or package environment is invalid.
     """
+    if env_file is None:
+        env_file = ENV_FILE
     if TAG_PATTERN.fullmatch(tag) is None:
         raise ReleaseValidationError(
             f"Invalid release tag: {tag}. Expected format: v26.5.0 or v26.5.0.dev1."

--- a/src/gpp_client/__init__.py
+++ b/src/gpp_client/__init__.py
@@ -2,9 +2,22 @@
 Top-level package for gpp_client.
 """
 
-from typing import Any
+import importlib.metadata
+from typing import TYPE_CHECKING, Any
 
-__all__ = ["GPPClient"]
+if TYPE_CHECKING:
+    from .client import GPPClient
+
+__all__ = ["GPPClient", "__version__"]
+
+_FALLBACK_VERSION = "0.0.0"
+
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    # Have fallback version for development environments.
+    __version__ = _FALLBACK_VERSION
 
 
 def __getattr__(name: str) -> Any:

--- a/src/gpp_client/cli/cli.py
+++ b/src/gpp_client/cli/cli.py
@@ -5,11 +5,11 @@ CLI entry point for GPP Client.
 __all__ = ["app"]
 
 from dataclasses import dataclass
-from importlib.metadata import version as get_version
 from typing import Annotated
 
 import typer
 
+from gpp_client import GPPClient, __version__
 from gpp_client.cli import output
 from gpp_client.cli.commands import (
     attachment_app,
@@ -22,10 +22,7 @@ from gpp_client.cli.commands import (
     workflow_state_app,
 )
 from gpp_client.cli.utils import async_command
-from gpp_client.client import GPPClient
 from gpp_client.settings import get_config_path as _get_config_path
-
-__version__ = get_version("gpp-client").strip()
 
 
 @dataclass(slots=True)

--- a/tests/scripts/test_validate_release.py
+++ b/tests/scripts/test_validate_release.py
@@ -1,0 +1,238 @@
+"""
+Tests for the release validation script.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from scripts import validate_release as release
+from scripts.validate_release import ReleaseValidationError
+
+
+@pytest.fixture()
+def env_file(tmp_path: Path) -> Path:
+    """
+    Return a temporary package environment file path.
+    """
+    return tmp_path / "src" / "gpp_client" / "generated" / "package_environment.py"
+
+
+def write_env_file(path: Path, environment: str) -> None:
+    """
+    Write a generated package environment file.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '"""\n'
+        "Package-level environment constant for generated client code.\n"
+        '"""\n\n'
+        f'PACKAGE_ENVIRONMENT = "{environment}"\n',
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("v26.5.0.dev1", "DEVELOPMENT"),
+        ("v26.5.0.dev12", "DEVELOPMENT"),
+        ("v26.5.0", "PRODUCTION"),
+        ("v26.12.3", "PRODUCTION"),
+    ],
+)
+def test_expected_environment(tag: str, expected: str) -> None:
+    """
+    Expected environment is inferred from the release tag.
+    """
+    assert release._expected_environment(tag) == expected
+
+
+@pytest.mark.parametrize("environment", ["DEVELOPMENT", "PRODUCTION"])
+def test_parse_environment_returns_environment(
+    env_file: Path,
+    environment: str,
+) -> None:
+    """
+    Environment is parsed from the generated environment file.
+    """
+    write_env_file(env_file, environment)
+
+    assert release._parse_environment(env_file) == environment
+
+
+def test_parse_environment_raises_for_missing_file(env_file: Path) -> None:
+    """
+    Missing environment file raises a release validation error.
+    """
+    with pytest.raises(ReleaseValidationError, match="Missing environment file"):
+        release._parse_environment(env_file)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "",
+        'PACKAGE_ENVIRONMENT = "STAGING"\n',
+        "PACKAGE_ENVIRONMENT = DEVELOPMENT\n",
+        'OTHER_ENVIRONMENT = "PRODUCTION"\n',
+        'PACKAGE_ENVIRONMENT: str = "PRODUCTION"\n',
+    ],
+)
+def test_parse_environment_raises_for_invalid_file_content(
+    env_file: Path,
+    content: str,
+) -> None:
+    """
+    Invalid environment file content raises a release validation error.
+    """
+    env_file.parent.mkdir(parents=True, exist_ok=True)
+    env_file.write_text(content, encoding="utf-8")
+
+    with pytest.raises(
+        ReleaseValidationError,
+        match="Could not find a valid PACKAGE_ENVIRONMENT",
+    ):
+        release._parse_environment(env_file)
+
+
+@pytest.mark.parametrize(
+    ("tag", "environment"),
+    [
+        ("v26.5.0.dev1", "DEVELOPMENT"),
+        ("v26.5.0.dev10", "DEVELOPMENT"),
+        ("v26.5.0", "PRODUCTION"),
+        ("v26.12.2", "PRODUCTION"),
+    ],
+)
+def test_validate_release_accepts_valid_tag_and_matching_environment(
+    env_file: Path,
+    tag: str,
+    environment: str,
+) -> None:
+    """
+    Valid release tags pass when the package environment matches.
+    """
+    write_env_file(env_file, environment)
+
+    release.validate_release(tag, env_file)
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "26.5.0",
+        "v2026.5.0",
+        "v26.05.0",
+        "v26.5",
+        "v26.5.0.1",
+        "v26.5.0-dev.1",
+        "v26.5.0.dev",
+        "v26.5.0.dev0.dev1",
+        "v26.5.0rc1",
+        "release-v26.5.0",
+        "",
+    ],
+)
+def test_validate_release_raises_for_invalid_tag(
+    env_file: Path,
+    tag: str,
+) -> None:
+    """
+    Invalid release tag formats raise a release validation error.
+    """
+    write_env_file(env_file, "PRODUCTION")
+
+    with pytest.raises(ReleaseValidationError, match="Invalid release tag"):
+        release.validate_release(tag, env_file)
+
+
+@pytest.mark.parametrize(
+    ("tag", "environment", "expected"),
+    [
+        ("v26.5.0.dev1", "PRODUCTION", "DEVELOPMENT"),
+        ("v26.5.0", "DEVELOPMENT", "PRODUCTION"),
+    ],
+)
+def test_validate_release_raises_for_environment_mismatch(
+    env_file: Path,
+    tag: str,
+    environment: str,
+    expected: str,
+) -> None:
+    """
+    Release validation fails when tag type and package environment mismatch.
+    """
+    write_env_file(env_file, environment)
+
+    with pytest.raises(ReleaseValidationError) as exc_info:
+        release.validate_release(tag, env_file)
+
+    message = str(exc_info.value)
+
+    assert "Package environment does not match release tag." in message
+    assert f"Tag: {tag}" in message
+    assert f"Expected PACKAGE_ENVIRONMENT: {expected}" in message
+    assert f"Actual PACKAGE_ENVIRONMENT: {environment}" in message
+
+
+def test_validate_release_uses_default_environment_file(
+    env_file: Path,
+    mocker,
+) -> None:
+    """
+    Default environment file is used when no path is provided.
+    """
+    write_env_file(env_file, "PRODUCTION")
+    mocker.patch.object(release, "ENV_FILE", env_file)
+
+    release.validate_release("v26.5.0", env_file=release.ENV_FILE)
+
+
+def test_main_exits_with_usage_when_tag_is_missing(mocker) -> None:
+    """
+    CLI exits with usage text when no tag is provided.
+    """
+    mocker.patch.object(release.sys, "argv", ["validate_release.py"])
+
+    with pytest.raises(SystemExit, match="Usage: validate_release.py <tag>"):
+        release.main()
+
+
+def test_main_exits_with_error_for_invalid_release(
+    env_file: Path,
+    mocker,
+    capsys,
+) -> None:
+    """
+    CLI exits with code 1 and writes validation errors to stderr.
+    """
+    write_env_file(env_file, "PRODUCTION")
+
+    mocker.patch.object(release, "ENV_FILE", env_file)
+    mocker.patch.object(release.sys, "argv", ["validate_release.py", "v26.5.0.dev1"])
+    mocker.patch.object(
+        release,
+        "validate_release",
+        side_effect=ReleaseValidationError("validation failed"),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        release.main()
+
+    captured = capsys.readouterr()
+
+    assert exc_info.value.code == 1
+    assert "validation failed" in captured.err
+
+
+def test_main_validates_tag_from_argv(mocker) -> None:
+    """
+    CLI passes the provided tag to release validation.
+    """
+    validate_release = mocker.patch.object(release, "validate_release")
+    mocker.patch.object(release.sys, "argv", ["validate_release.py", "v26.5.0"])
+
+    release.main()
+
+    validate_release.assert_called_once_with("v26.5.0")

--- a/uv.lock
+++ b/uv.lock
@@ -850,7 +850,6 @@ wheels = [
 
 [[package]]
 name = "gpp-client"
-version = "26.4.1.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
<!--
General pull request.

Versioning:
- Do not bump the version in default PRs.
- Version changes only occur in release PRs using `uv version`.

Docs:
- If your change affects documentation, run the live docs server:
    uv sync --group docs
    uv run sphinx-autobuild docs/source docs/build
- Then open:
    http://127.0.0.1:8000
- This rebuilds automatically on file changes.

Testing:
- Run linting and tests locally before requesting review.
    uv run --dev pytest

-->

## Checklist
- [x] Linting and tests pass.
- [ ] If this PR changes GraphQL types or queries, the codegen has regenerated the  models.
- [ ] Documentation builds cleanly (if docs were modified).
