### PR TITLE
GPC-137: Update dependencies for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -14,6 +14,7 @@ updates:
           - "graphql-core"
           - "httpx"
           - "pydantic"
+          - "pydantic-settings"
           - "typer"
           - "websockets"
       codegen-dependencies:
@@ -31,6 +32,10 @@ updates:
       schema-dependencies:
         patterns:
           - "gql"
+      notebook-dependencies:
+        patterns:
+          - "ipykernel"
+          - "jupyter"
 
   # Enable version updates for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!--
General pull request.

Versioning:
- Do not bump the version in default PRs.
- Version changes only occur in release PRs using `uv version`.

Docs:
- If your change affects documentation, run the live docs server:
    uv sync --group docs
    uv run sphinx-autobuild docs/source docs/build
- Then open:
    http://127.0.0.1:8000
- This rebuilds automatically on file changes.

Testing:
- Run linting and tests locally before requesting review.
    uv run --dev pytest

-->

## Checklist
- [x] Linting and tests pass.
- [x] If this PR changes GraphQL types or queries, the codegen has regenerated the  models.
- [x] Documentation builds cleanly (if docs were modified).
