### PR TITLE
Apply fixes for tag timing and uv aggressive metadata with dynamic values

### DIFF
--- a/.github/workflows/create_release.yaml
+++ b/.github/workflows/create_release.yaml
@@ -55,6 +55,12 @@ jobs:
       - name: Run tests
         run: uv run pytest
 
+      - name: Create local tag
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ inputs.tag }}" -m "Release ${{ inputs.tag }}."
+
       - name: Clean distributions
         run: rm -rf dist
 
@@ -67,12 +73,8 @@ jobs:
           uv pip install --python /tmp/gpp-client-smoke/bin/python dist/*.whl
           /tmp/gpp-client-smoke/bin/python -c "import gpp_client; print(gpp_client.__version__)"
 
-      - name: Create and push tag
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ inputs.tag }}" -m "Release ${{ inputs.tag }}."
-          git push origin "${{ inputs.tag }}"
+      - name: Push tag
+        run: git push origin "${{ inputs.tag }}"
 
       - name: Create draft GitHub release
         uses: softprops/action-gh-release@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ strict = true
 metadata = false
 fallback-version = "0.0.0"
 
+[tool.uv]
+cache-keys = [{ file = "pyproject.toml" }, { git = { commit = true, tags = true }}]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/gpp_client"]
 


### PR DESCRIPTION

<!--
General pull request.

Versioning:
- Do not bump the version in default PRs.
- Version changes only occur in release PRs using `uv version`.

Docs:
- If your change affects documentation, run the live docs server:
    uv sync --group docs
    uv run sphinx-autobuild docs/source docs/build
- Then open:
    http://127.0.0.1:8000
- This rebuilds automatically on file changes.

Testing:
- Run linting and tests locally before requesting review.
    uv run --dev pytest

-->

## Checklist
- [x] Linting and tests pass.
- [ ] If this PR changes GraphQL types or queries, the codegen has regenerated the  models.
- [x] Documentation builds cleanly (if docs were modified).
