### PR TITLE
GPC-149: Fix workflow state update to return Pydantic model

### DIFF
--- a/src/gpp_client/domains/workflow_state.py
+++ b/src/gpp_client/domains/workflow_state.py
@@ -6,16 +6,19 @@ __all__ = ["WorkflowStateDomain"]
 
 import asyncio
 import logging
-from typing import Any
 
 from gpp_client.domains.base import BaseDomain
 from gpp_client.exceptions import GPPClientError, GPPRetryableError, GPPValidationError
 from gpp_client.generated.enums import CalculationState, ObservationWorkflowState
 from gpp_client.generated.get_observation_workflow_state_by_id import (
     GetObservationWorkflowStateById,
+    GetObservationWorkflowStateByIdObservationWorkflow,
 )
 from gpp_client.generated.get_observation_workflow_state_by_reference import (
     GetObservationWorkflowStateByReference,
+)
+from gpp_client.generated.set_observation_workflow_state import (
+    SetObservationWorkflowStateSetObservationWorkflowState,
 )
 
 logger = logging.getLogger(__name__)
@@ -73,7 +76,7 @@ class WorkflowStateDomain(BaseDomain):
         observation_id: str,
         *,
         workflow_state: ObservationWorkflowState,
-    ) -> dict[str, Any]:
+    ) -> SetObservationWorkflowStateSetObservationWorkflowState:
         """
         Update the workflow state of an observation by its ID, or return the current
         workflow if already set.
@@ -95,8 +98,8 @@ class WorkflowStateDomain(BaseDomain):
 
         Returns
         -------
-        dict[str, Any]
-            The returned workflow state for the observation.
+        SetObservationWorkflowStateSetObservationWorkflowState
+            The workflow details for the observation after the operation.
 
         Raises
         ------
@@ -113,7 +116,7 @@ class WorkflowStateDomain(BaseDomain):
             workflow_state.value,
         )
         result = await self.get_by_id(observation_id=observation_id)
-        workflow = result["workflow"]
+        workflow = result.observation.workflow
 
         # If calculation is not 'READY', raise an error to retry later.
         try:
@@ -121,25 +124,35 @@ class WorkflowStateDomain(BaseDomain):
         except RuntimeError as exc:
             self.raise_error(GPPRetryableError, exc)
 
-        # If the desired state is already set, return as-is.
+        # If the desired state is already set, return the current workflow
+        # rebuilt as the mutation response model.
         if _check_already_set(workflow, workflow_state):
-            # Return the same shape as other return paths.
             logger.debug(
                 "Workflow state for observation ID %s is already %s; no update needed.",
                 observation_id,
                 workflow_state.value,
             )
-            return workflow["value"]
+            return (
+                SetObservationWorkflowStateSetObservationWorkflowState.model_validate(
+                    workflow.value.model_dump(by_alias=True)
+                )
+            )
         # Validate the requested workflow state against 'validTransitions'.
         try:
             _check_valid_transition(workflow, workflow_state)
         except ValueError as exc:
             self.raise_error(GPPValidationError, exc)
 
-        return await self._graphql.set_observation_workflow_state(
+        mutation_result = await self._graphql.set_observation_workflow_state(
             observation_id=observation_id,
             state=workflow_state,
         )
+        payload = mutation_result.set_observation_workflow_state
+        if payload is None:
+            raise GPPClientError(
+                "GPP returned no payload for setObservationWorkflowState."
+            )
+        return payload
 
     async def update_by_id_with_retry(
         self,
@@ -149,7 +162,7 @@ class WorkflowStateDomain(BaseDomain):
         max_attempts: int = 10,
         initial_delay: float = 0.0,
         retry_delay: float = 1.0,
-    ) -> dict[str, Any]:
+    ) -> SetObservationWorkflowStateSetObservationWorkflowState:
         """
         Update the workflow state of an observation by its ID, retrying if the
         observation is not ready.
@@ -172,8 +185,8 @@ class WorkflowStateDomain(BaseDomain):
 
         Returns
         -------
-        dict[str, Any]
-            The returned workflow state for the observation.
+        SetObservationWorkflowStateSetObservationWorkflowState
+            The workflow details for the observation after the operation.
 
         Raises
         ------
@@ -216,30 +229,30 @@ class WorkflowStateDomain(BaseDomain):
         self.raise_error(type(exc), exc)
 
 
-def _check_ready(workflow: dict[str, Any]) -> None:
+def _check_ready(workflow: GetObservationWorkflowStateByIdObservationWorkflow) -> None:
     """
     Raise an error if the observation calculation is not in the ``READY`` state.
 
     Parameters
     ----------
-    workflow : dict[str, Any]
-        The workflow data structure returned by ``get_by_id()``.
+    workflow : GetObservationWorkflowStateByIdObservationWorkflow
+        The workflow Pydantic model returned by ``get_by_id().observation.workflow``.
 
     Raises
     ------
     RuntimeError
         If the calculation state is not ``READY``.
     """
-    if workflow["state"] != CalculationState.READY.value:
+    if workflow.state != CalculationState.READY:
         raise RuntimeError(
             "Observation calculation is not READY (current state: "
-            f"{workflow['state']}). Please retry after background processing "
+            f"{workflow.state.value}). Please retry after background processing "
             "is complete."
         )
 
 
 def _check_already_set(
-    workflow: dict[str, Any],
+    workflow: GetObservationWorkflowStateByIdObservationWorkflow,
     workflow_state: ObservationWorkflowState,
 ) -> bool:
     """
@@ -247,8 +260,8 @@ def _check_already_set(
 
     Parameters
     ----------
-    workflow : dict[str, Any]
-        The workflow data structure returned by ``get_by_id()``.
+    workflow : GetObservationWorkflowStateByIdObservationWorkflow
+        The workflow Pydantic model returned by ``get_by_id().observation.workflow``.
     workflow_state : ObservationWorkflowState
         The desired workflow state.
 
@@ -258,11 +271,11 @@ def _check_already_set(
         ``True`` if the current workflow state matches the desired state,
         otherwise ``False``.
     """
-    return workflow["value"]["state"] == workflow_state.value
+    return workflow.value.state == workflow_state
 
 
 def _check_valid_transition(
-    workflow: dict[str, Any],
+    workflow: GetObservationWorkflowStateByIdObservationWorkflow,
     workflow_state: ObservationWorkflowState,
 ) -> None:
     """
@@ -270,8 +283,8 @@ def _check_valid_transition(
 
     Parameters
     ----------
-    workflow : dict[str, Any]
-        The workflow data structure returned by ``get_by_id()``.
+    workflow : GetObservationWorkflowStateByIdObservationWorkflow
+        The workflow Pydantic model returned by ``get_by_id().observation.workflow``.
     workflow_state : ObservationWorkflowState
         The desired workflow state to transition to.
 
@@ -281,9 +294,9 @@ def _check_valid_transition(
         If the requested transition is not allowed based on
         ``validTransitions``.
     """
-    valid_transitions = workflow["value"].get("validTransitions", [])
-    if workflow_state.value not in valid_transitions:
-        valid_str = ", ".join(valid_transitions) or "None"
+    valid_transitions = workflow.value.valid_transitions or []
+    if workflow_state not in valid_transitions:
+        valid_str = ", ".join(t.value for t in valid_transitions) or "None"
         raise ValueError(
             f"Cannot transition to '{workflow_state.value}'. "
             f"Valid transitions are: {valid_str}."

--- a/tests/gpp_client/domains/test_workflow_state.py
+++ b/tests/gpp_client/domains/test_workflow_state.py
@@ -14,6 +14,64 @@ from gpp_client.domains.workflow_state import (
 )
 from gpp_client.exceptions import GPPClientError, GPPRetryableError, GPPValidationError
 from gpp_client.generated.enums import CalculationState, ObservationWorkflowState
+from gpp_client.generated.fragments import WorkflowDetailsValue
+from gpp_client.generated.get_observation_workflow_state_by_id import (
+    GetObservationWorkflowStateById,
+    GetObservationWorkflowStateByIdObservation,
+    GetObservationWorkflowStateByIdObservationWorkflow,
+)
+from gpp_client.generated.set_observation_workflow_state import (
+    SetObservationWorkflowState,
+    SetObservationWorkflowStateSetObservationWorkflowState,
+)
+
+
+def _build_workflow(
+    calculation_state: CalculationState,
+    workflow_state: ObservationWorkflowState,
+    valid_transitions: list[ObservationWorkflowState],
+) -> GetObservationWorkflowStateByIdObservationWorkflow:
+    """
+    Build a workflow Pydantic model for testing.
+    """
+    value = WorkflowDetailsValue.model_construct(
+        state=workflow_state,
+        valid_transitions=valid_transitions,
+        validation_errors=[],
+    )
+    return GetObservationWorkflowStateByIdObservationWorkflow.model_construct(
+        state=calculation_state,
+        value=value,
+    )
+
+
+def _build_get_by_id_result(
+    workflow: GetObservationWorkflowStateByIdObservationWorkflow,
+) -> GetObservationWorkflowStateById:
+    """
+    Wrap a workflow into the full ``get_by_id`` response model.
+    """
+    observation = GetObservationWorkflowStateByIdObservation.model_construct(
+        workflow=workflow,
+    )
+    return GetObservationWorkflowStateById.model_construct(observation=observation)
+
+
+def _build_mutation_result(
+    workflow_state: ObservationWorkflowState,
+    valid_transitions: list[ObservationWorkflowState] | None = None,
+) -> SetObservationWorkflowState:
+    """
+    Build a ``set_observation_workflow_state`` mutation response model.
+    """
+    payload = SetObservationWorkflowStateSetObservationWorkflowState.model_construct(
+        state=workflow_state,
+        valid_transitions=valid_transitions or [],
+        validation_errors=[],
+    )
+    return SetObservationWorkflowState.model_construct(
+        set_observation_workflow_state=payload,
+    )
 
 
 @pytest.fixture()
@@ -74,9 +132,11 @@ def test_check_ready_allows_ready_state() -> None:
     """
     Ensure _check_ready accepts READY workflows.
     """
-    workflow = {
-        "state": CalculationState.READY.value,
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[],
+    )
 
     _check_ready(workflow)
 
@@ -85,9 +145,11 @@ def test_check_ready_raises_for_non_ready_state() -> None:
     """
     Ensure _check_ready raises for non-READY workflows.
     """
-    workflow = {
-        "state": "PENDING",
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.PENDING,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[],
+    )
 
     with pytest.raises(RuntimeError):
         _check_ready(workflow)
@@ -97,11 +159,11 @@ def test_check_already_set_returns_true_when_matching() -> None:
     """
     Ensure _check_already_set returns true for matching states.
     """
-    workflow = {
-        "value": {
-            "state": ObservationWorkflowState.READY.value,
-        }
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[],
+    )
 
     assert _check_already_set(workflow, ObservationWorkflowState.READY) is True
 
@@ -110,11 +172,11 @@ def test_check_already_set_returns_false_when_different() -> None:
     """
     Ensure _check_already_set returns false for different states.
     """
-    workflow = {
-        "value": {
-            "state": ObservationWorkflowState.READY.value,
-        }
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[],
+    )
 
     assert _check_already_set(workflow, ObservationWorkflowState.ONGOING) is False
 
@@ -123,11 +185,11 @@ def test_check_valid_transition_allows_valid_transition() -> None:
     """
     Ensure _check_valid_transition accepts valid transitions.
     """
-    workflow = {
-        "value": {
-            "validTransitions": [ObservationWorkflowState.ONGOING.value],
-        }
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
 
     _check_valid_transition(workflow, ObservationWorkflowState.ONGOING)
 
@@ -136,11 +198,11 @@ def test_check_valid_transition_raises_for_invalid_transition() -> None:
     """
     Ensure _check_valid_transition raises for invalid transitions.
     """
-    workflow = {
-        "value": {
-            "validTransitions": [ObservationWorkflowState.ONGOING.value],
-        }
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
 
     with pytest.raises(ValueError):
         _check_valid_transition(workflow, ObservationWorkflowState.INACTIVE)
@@ -154,16 +216,15 @@ async def test_update_by_id_returns_existing_value_when_already_set(
     """
     Ensure update_by_id returns existing workflow when already set.
     """
-    workflow_value = {
-        "state": ObservationWorkflowState.READY.value,
-        "validTransitions": [ObservationWorkflowState.ONGOING.value],
-    }
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
     get_by_id = mocker.patch.object(
         workflow_state_domain,
         "get_by_id",
-        return_value={
-            "workflow": {"state": CalculationState.READY.value, "value": workflow_value}
-        },
+        return_value=_build_get_by_id_result(workflow),
     )
     set_state = mocker.patch.object(
         workflow_state_domain._graphql,
@@ -176,7 +237,9 @@ async def test_update_by_id_returns_existing_value_when_already_set(
         workflow_state=ObservationWorkflowState.READY,
     )
 
-    assert result == workflow_value
+    assert isinstance(result, SetObservationWorkflowStateSetObservationWorkflowState)
+    assert result.state == ObservationWorkflowState.READY
+    assert result.valid_transitions == [ObservationWorkflowState.ONGOING]
     get_by_id.assert_called_once_with(observation_id="o-1")
     set_state.assert_not_called()
 
@@ -189,24 +252,23 @@ async def test_update_by_id_sets_new_state_when_valid(
     """
     Ensure update_by_id performs mutation for valid transitions.
     """
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
     get_by_id = mocker.patch.object(
         workflow_state_domain,
         "get_by_id",
-        return_value={
-            "workflow": {
-                "state": CalculationState.READY.value,
-                "value": {
-                    "state": ObservationWorkflowState.READY.value,
-                    "validTransitions": [ObservationWorkflowState.ONGOING.value],
-                },
-            }
-        },
+        return_value=_build_get_by_id_result(workflow),
     )
-    result_model = {"state": ObservationWorkflowState.ONGOING.value}
+    mutation_result = _build_mutation_result(
+        workflow_state=ObservationWorkflowState.ONGOING,
+    )
     set_state = mocker.patch.object(
         workflow_state_domain._graphql,
         "set_observation_workflow_state",
-        new=mocker.AsyncMock(return_value=result_model),
+        new=mocker.AsyncMock(return_value=mutation_result),
     )
 
     result = await workflow_state_domain.update_by_id(
@@ -214,12 +276,48 @@ async def test_update_by_id_sets_new_state_when_valid(
         workflow_state=ObservationWorkflowState.ONGOING,
     )
 
-    assert result == result_model
+    assert isinstance(result, SetObservationWorkflowStateSetObservationWorkflowState)
+    assert result.state == ObservationWorkflowState.ONGOING
+    assert result.valid_transitions == []
     get_by_id.assert_called_once_with(observation_id="o-1")
     set_state.assert_called_once_with(
         observation_id="o-1",
         state=ObservationWorkflowState.ONGOING,
     )
+
+
+@pytest.mark.asyncio
+async def test_update_by_id_raises_when_mutation_payload_missing(
+    workflow_state_domain,
+    mocker,
+) -> None:
+    """
+    Ensure update_by_id raises when GPP returns no mutation payload.
+    """
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
+    mocker.patch.object(
+        workflow_state_domain,
+        "get_by_id",
+        return_value=_build_get_by_id_result(workflow),
+    )
+    empty_result = SetObservationWorkflowState.model_construct(
+        set_observation_workflow_state=None,
+    )
+    mocker.patch.object(
+        workflow_state_domain._graphql,
+        "set_observation_workflow_state",
+        new=mocker.AsyncMock(return_value=empty_result),
+    )
+
+    with pytest.raises(GPPClientError):
+        await workflow_state_domain.update_by_id(
+            observation_id="o-1",
+            workflow_state=ObservationWorkflowState.ONGOING,
+        )
 
 
 @pytest.mark.asyncio
@@ -230,18 +328,15 @@ async def test_update_by_id_raises_retryable_error_when_not_ready(
     """
     Ensure update_by_id raises retryable error when calculation is not ready.
     """
+    workflow = _build_workflow(
+        calculation_state=CalculationState.PENDING,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
     mocker.patch.object(
         workflow_state_domain,
         "get_by_id",
-        return_value={
-            "workflow": {
-                "state": "PENDING",
-                "value": {
-                    "state": ObservationWorkflowState.READY.value,
-                    "validTransitions": [ObservationWorkflowState.ONGOING.value],
-                },
-            }
-        },
+        return_value=_build_get_by_id_result(workflow),
     )
 
     with pytest.raises(GPPRetryableError):
@@ -259,18 +354,15 @@ async def test_update_by_id_raises_validation_error_for_invalid_transition(
     """
     Ensure update_by_id raises validation error for invalid transitions.
     """
+    workflow = _build_workflow(
+        calculation_state=CalculationState.READY,
+        workflow_state=ObservationWorkflowState.READY,
+        valid_transitions=[ObservationWorkflowState.ONGOING],
+    )
     mocker.patch.object(
         workflow_state_domain,
         "get_by_id",
-        return_value={
-            "workflow": {
-                "state": CalculationState.READY.value,
-                "value": {
-                    "state": ObservationWorkflowState.READY.value,
-                    "validTransitions": [ObservationWorkflowState.ONGOING.value],
-                },
-            }
-        },
+        return_value=_build_get_by_id_result(workflow),
     )
 
     with pytest.raises(GPPValidationError):


### PR DESCRIPTION
## Summary

WorkflowStateDomain.update_by_id was treating the response from get_observation_workflow_state_by_id as a dict (result["workflow"], workflow["value"]["state"], etc.), which broke at runtime once the call returned a Pydantic model. Every call through update_by_id_with_retry by GOATS raised 'GetObservationWorkflowStateById' object is not subscriptable.

## Checklist

- [ ] Documentation was updated, if needed.
- [ ] Generated GraphQL code was updated, if schema or operation files changed.

## Breaking Changes

- [ ] This change introduces a breaking API or behavior change.
<!-- If checked, describe the migration impact below. -->
